### PR TITLE
Add Azure GPT chess agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# focused-todo
+# AI Chess Battle
+
+This repo contains a simple Streamlit application where two language models play chess against each other.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Configure Azure OpenAI credentials and deployments via environment variables:
+   ```bash
+   export AZURE_OPENAI_API_KEY=your_api_key
+   export AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+   export AZURE_OPENAI_API_VERSION=2024-05-13
+   export AGENT1_DEPLOYMENT=gpt-deployment-1
+   export AGENT2_DEPLOYMENT=gpt-deployment-2
+   ```
+
+3. Launch the Streamlit app:
+   ```bash
+   streamlit run app.py
+   ```
+
+The app alternates moves between two Azure GPT deployments. After the specified number of moves, a simple material evaluation indicates which side has the advantage.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,106 @@
+import os
+import streamlit as st
+import chess
+import chess.svg
+from typing import Optional
+
+try:
+    import openai
+except ImportError:
+    openai = None
+
+# Helper to configure Azure OpenAI
+AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY", "")
+AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT", "")
+AZURE_OPENAI_API_VERSION = os.getenv("AZURE_OPENAI_API_VERSION", "2024-05-13")
+
+AGENT1_DEPLOYMENT = os.getenv("AGENT1_DEPLOYMENT", "gpt-deployment-1")
+AGENT2_DEPLOYMENT = os.getenv("AGENT2_DEPLOYMENT", "gpt-deployment-2")
+
+if openai and AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT:
+    openai.api_type = "azure"
+    openai.api_key = AZURE_OPENAI_API_KEY
+    openai.api_base = AZURE_OPENAI_ENDPOINT
+    openai.api_version = AZURE_OPENAI_API_VERSION
+
+
+def request_gpt(deployment: str, prompt: str) -> str:
+    """Call Azure OpenAI deployment and return the text response."""
+    if not openai:
+        return "openai package not installed."
+    try:
+        response = openai.ChatCompletion.create(
+            engine=deployment,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+        return response["choices"][0]["message"]["content"].strip()
+    except Exception as e:
+        return f"Error from Azure OpenAI: {e}"
+
+
+def evaluate_board(board: chess.Board) -> int:
+    """Simple material evaluation. Positive for white advantage."""
+    piece_values = {
+        chess.PAWN: 1,
+        chess.KNIGHT: 3,
+        chess.BISHOP: 3,
+        chess.ROOK: 5,
+        chess.QUEEN: 9,
+        chess.KING: 0,
+    }
+    value = 0
+    for piece_type in piece_values:
+        value += len(board.pieces(piece_type, chess.WHITE)) * piece_values[piece_type]
+        value -= len(board.pieces(piece_type, chess.BLACK)) * piece_values[piece_type]
+    return value
+
+
+def display_board(board: chess.Board):
+    svg = chess.svg.board(board=board)
+    st.components.v1.html(svg, height=400)
+
+
+def main():
+    st.title("AI Chess Battle")
+    st.write("Two AI agents play chess using GPT models.")
+
+    board = chess.Board()
+    num_moves = st.number_input("Number of moves", min_value=1, max_value=100, value=10)
+    start_button = st.button("Start Game")
+
+    if start_button:
+        for move_number in range(num_moves):
+            agent = "Agent 1" if move_number % 2 == 0 else "Agent 2"
+            deployment = AGENT1_DEPLOYMENT if move_number % 2 == 0 else AGENT2_DEPLOYMENT
+            prompt = f"Current board in FEN: {board.fen()}\nProvide next move in algebraic notation only."
+            move_str = request_gpt(deployment, prompt)
+
+            st.write(f"**{agent} move {move_number+1}:** {move_str}")
+
+            try:
+                move = board.parse_san(move_str)
+                board.push(move)
+            except Exception as e:
+                st.write(f"Invalid move from {agent}: {e}")
+                break
+
+            display_board(board)
+
+            if board.is_game_over():
+                st.write("Game over!", board.result())
+                break
+
+        score = evaluate_board(board)
+        if score > 0:
+            st.write("White advantage")
+        elif score < 0:
+            st.write("Black advantage")
+        else:
+            st.write("Even position")
+
+        st.write(f"Evaluation score: {score}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 numpy
+streamlit
+openai
+python-chess


### PR DESCRIPTION
## Summary
- modify README to describe Azure OpenAI setup
- switch chess app to use two Azure GPT deployments
- drop Anthropic dependency

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_683fe787e0f483319c47250b977210c2